### PR TITLE
보정 상수 기본값 0으로 수정

### DIFF
--- a/hit.html
+++ b/hit.html
@@ -79,8 +79,8 @@
   </div>
 
   <div class="slider-group">
-    <div class="label">🟨 기초 회피력 (보정 상수): <span id="eva_val" class="value">15</span></div>
-    <input type="range" id="eva" min="0" max="100" value="15" oninput="update()">
+    <div class="label">🟨 기초 회피력 (보정 상수): <span id="eva_val" class="value">0</span></div>
+    <input type="range" id="eva" min="0" max="100" value="0" oninput="update()">
   </div>
 
   <div class="result" id="output"></div>


### PR DESCRIPTION
## 변경 내용
- 명중률 계산기에서 기초 회피력 기본값을 15에서 0으로 수정했습니다.

## 테스트
- 별도의 테스트 스크립트가 없어 기능 변경 후 파일이 정상적으로 반영되는지 확인했습니다.

------
https://chatgpt.com/codex/tasks/task_e_685d0160350083319c9bc786f5a98e67