### PR TITLE
보정 상수 초기값 0으로 변경

### DIFF
--- a/hit.html
+++ b/hit.html
@@ -79,8 +79,8 @@
   </div>
 
   <div class="slider-group">
-    <div class="label">🟨 기초 회피력 (보정 상수): <span id="eva_val" class="value">15</span></div>
-    <input type="range" id="eva" min="0" max="100" value="15" oninput="update()">
+    <div class="label">🟨 기초 회피력 (보정 상수): <span id="eva_val" class="value">0</span></div>
+    <input type="range" id="eva" min="0" max="100" value="0" oninput="update()">
   </div>
 
   <div class="result" id="output"></div>


### PR DESCRIPTION
## 요약
- 명중률 계산기에서 `기초 회피력(보정 상수)` 슬라이더의 기본값을 **15**에서 **0**으로 수정했습니다.

## 테스트
- 별도의 테스트 스크립트가 없어 기본 동작만 확인했습니다.

------
https://chatgpt.com/codex/tasks/task_e_685d0564480c8331a8ec2c811849814b