### PR TITLE
메인 타이틀 애니메이션 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
       ctx.fillStyle = '#ffd700';
       ctx.fillText(text, 10, baseline);
       const img = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      const step = 8;
+      const step = 4;
       let dots = [];
       for (let y = 0; y < canvas.height; y += step) {
         for (let x = 0; x < canvas.width; x += step) {
@@ -117,11 +117,15 @@
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       drawDots();
       let pacX = -20;
-      const pacY = canvas.height / 2;
+      let pacY = canvas.height / 2;
+      const startX = pacX;
+      const startY = pacY;
       const pacRadius = 15;
       const monsterX = canvas.width * 0.75;
       const monsterRadius = pacRadius + 5;
-      let gameOver = false;
+      const duration = 4000;
+      const amplitude = canvas.height / 4;
+      let startTime;
       let mouth = 0;
       function drawPacman() {
         const angle = 0.25 + Math.abs(Math.sin(mouth)) * 0.25;
@@ -135,10 +139,14 @@
       function drawMonster() {
         ctx.fillStyle = 'red';
         ctx.beginPath();
-        ctx.arc(monsterX, pacY, monsterRadius, 0, Math.PI * 2);
+        ctx.arc(monsterX, startY, monsterRadius, 0, Math.PI * 2);
         ctx.fill();
       }
-      function animate() {
+      function animate(timestamp) {
+        if (!startTime) startTime = timestamp;
+        const t = Math.min((timestamp - startTime) / duration, 1);
+        pacX = startX + (monsterX - startX) * t;
+        pacY = startY + amplitude * Math.sin(t * Math.PI * 4);
         ctx.fillStyle = getComputedStyle(document.body).getPropertyValue('--bg-color') || '#000';
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         dots = dots.filter(d => {
@@ -153,18 +161,7 @@
         });
         drawPacman();
         drawMonster();
-        if (!gameOver && Math.abs(pacX - monsterX) < pacRadius + monsterRadius) {
-          gameOver = true;
-          ctx.font = 'bold 40px monospace';
-          ctx.fillStyle = 'red';
-          ctx.textAlign = 'center';
-          ctx.fillText('GAME OVER', canvas.width / 2, canvas.height / 2);
-          return setTimeout(finish, 1000);
-        }
-        pacX += 2;
-        if (pacX - pacRadius > canvas.width) {
-          if (dots.length === 0) return finish();
-        }
+        if (t >= 1) return setTimeout(finish, 500);
         requestAnimationFrame(animate);
       }
       function finish() {


### PR DESCRIPTION
## 변경 내용
- 도트 간격을 줄여 해상도 향상
- 팩맨 이동 경로를 사인 곡선 기반으로 수정하고 지속 시간을 4초로 조정
- 충돌 시 게임 오버 문구 대신 자연스럽게 소멸하도록 변경

## 테스트 결과
- `python3 test_pages.py` 실행 결과 모든 테스트 통과

------
https://chatgpt.com/codex/tasks/task_e_685dd3c703008331bcadfb1bdb2e47e8