### PR TITLE
enhancement 페이지 UI 추가

### DIFF
--- a/enhancement.html
+++ b/enhancement.html
@@ -5,11 +5,63 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>아이템 강화 시뮬레이터</title>
   <style>
-    /* ...기존 스타일 유지... */
+    :root {
+      --bg-color: #f4f4f4;
+      --text-color: #000000;
+      --container-bg: #ffffff;
+      --border-color: #dddddd;
+      --control-bg: #eeeeee;
+      --control-hover: #dddddd;
+      --shadow: rgba(0,0,0,0.1);
+    }
+    html.dark {
+      --bg-color: #121212;
+      --text-color: #e0e0e0;
+      --container-bg: #1e1e1e;
+      --border-color: #333333;
+      --control-bg: #2c2c2c;
+      --control-hover: #3a3a3a;
+      --shadow: rgba(0,0,0,0.5);
+    }
+    body {
+      font-family: sans-serif;
+      margin: 0;
+      padding: 16px;
+      background: var(--bg-color);
+      color: var(--text-color);
+      transition: background-color .3s, color .3s;
+    }
+    .theme-toggle { position: absolute; top: 10px; right: 10px; }
+    .theme-btn { background: none; border: none; font-size: 1.5rem; filter: grayscale(100%); cursor: pointer; transition: filter .3s; color: var(--text-color); }
+    .theme-btn:hover { filter: grayscale(0%); }
+    .controls { display: flex; gap: 4px; margin-bottom: 8px; }
+    .controls button { padding: 4px 8px; background: var(--control-bg); border: 1px solid var(--border-color); border-radius: 4px; cursor: pointer; color: var(--text-color); }
+    .controls button:hover { background: var(--control-hover); }
+    #enhance-bar { display: flex; gap: 4px; margin-bottom: 8px; }
+    .step { flex: 1; padding: 4px; text-align: center; border: 1px solid var(--border-color); background: var(--control-bg); cursor: pointer; }
+    .step.selected { background: var(--control-hover); }
+    .step.safe { font-weight: bold; }
+    #entry-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 4px; margin-bottom: 8px; }
+    .slot { width: 60px; height: 60px; border: 1px solid var(--border-color); background: var(--container-bg); display: flex; align-items: center; justify-content: center; }
+    .card { font-weight: bold; }
+    .success { animation: successFlash 0.5s; }
+    .fail { animation: failFlash 0.5s; }
+    @keyframes successFlash { from { background: green; } to { background: inherit; } }
+    @keyframes failFlash { from { background: red; } to { background: inherit; } }
   </style>
 </head>
 <body>
-  <!-- ...기존 HTML 구조 유지... -->
+  <div class="theme-toggle"><button id="toggleTheme" class="theme-btn">🌙</button></div>
+  <h1>아이템 강화 시뮬레이터</h1>
+  <div class="controls">
+    <button onclick="registerItem('무기', 6)">무기 등록</button>
+    <button onclick="registerItem('방어구', 1)">방어구 등록</button>
+    <button onclick="resetAll()">초기화</button>
+  </div>
+  <div id="enhance-bar"></div>
+  <div id="entry-grid"></div>
+  <label><input type="checkbox" id="blessScroll"> 축복 두루마리</label>
+  <button onclick="enhanceAllSteps()">강화 실행</button>
 
   <script>
     // 1) entries 선언 및 슬롯 초기화
@@ -181,6 +233,7 @@
         await new Promise(r => requestAnimationFrame(r));
       }
     }
+    document.getElementById('toggleTheme').addEventListener('click', () => document.documentElement.classList.toggle('dark'));
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
       <li><a href="gift.html">6월선물상자 시뮬</a></li>
       <li><a href="points.html">바르아 포인트계산기</a></li>
       <li><a href="hit.html">명중률 계산기</a></li>
+      <li><a href="enhancement.html">아이템 강화 시뮬</a></li>
     </ul>
   </nav>
   <script>

--- a/test_pages.py
+++ b/test_pages.py
@@ -1,7 +1,7 @@
 import re
 import unittest
 
-HTML_FILES = ['index.html', 'gift.html', 'hit.html', 'points.html']
+HTML_FILES = ['index.html', 'gift.html', 'hit.html', 'points.html', 'enhancement.html']
 
 class TestDarkMode(unittest.TestCase):
     def test_dark_mode_support(self):


### PR DESCRIPTION
## 변경 사항
- `enhancement.html`에 누락된 UI와 스타일을 추가하여 다크 모드 지원
- 메인 페이지에서 강화 시뮬레이터로 이동할 수 있도록 메뉴 항목 추가
- 테스트 스크립트에 `enhancement.html` 포함

## 테스트 결과
- `python3 test_pages.py` 통과

------
https://chatgpt.com/codex/tasks/task_e_685eb0bd0dd483319f7f218d0af2a8be