### PR TITLE
강화 확률표 모듈화

### DIFF
--- a/enhance_rates.js
+++ b/enhance_rates.js
@@ -1,0 +1,35 @@
+window.enhanceRates = {
+  "무기": {
+    "6": {
+      "0": { "base":1,    "bless":[0.34,0.33,0.33], "break":false },
+      "1": { "base":1,    "bless":[0.34,0.33,0.33], "break":false },
+      "2": { "base":1,    "bless":[0.34,0.33,0.33], "break":false },
+      "3": { "base":1,    "bless":[0.50,0.50],      "break":false },
+      "4": { "base":1,    "bless":[0.50,0.50],      "break":false },
+      "5": { "base":1,    "bless":[0.50,0.50],      "break":false },
+      "6": { "base":0.51, "bless":[0.51],           "break":true  },
+      "7": { "base":0.33, "bless":[0.33],           "break":true  },
+      "8": { "base":0.33, "bless":[0.33],           "break":true  },
+      "9": { "base":0.10, "bless":[0.10],           "break":true  },
+      "10":{ "base":0.04, "bless":[0.04],           "break":true  },
+      "11":{ "base":0.01, "bless":[0.01],           "break":true  }
+    }
+  },
+  "방어구": {
+    "1": {
+      "0": { "base":1,      "bless":[0.3334,0.3333,0.3333], "break":false },
+      "1": { "base":0.7501,  "bless":[0.2501,0.25,0.25],     "break":true  },
+      "2": { "base":0.49,    "bless":[0.1634,0.1633,0.1633], "break":true  },
+      "3": { "base":0.33,    "bless":[0.165,0.165],          "break":true  },
+      "4": { "base":0.25,    "bless":[0.125,0.125],          "break":true  },
+      "5": { "base":0.20,    "bless":[0.10,0.10],            "break":true  },
+      "6": { "base":0.20,    "bless":[0.20],                 "break":true  },
+      "7": { "base":0.15,    "bless":[0.15],                 "break":true  },
+      "8": { "base":0.15,    "bless":[0.15],                 "break":true  },
+      "9": { "base":0.10,    "bless":[0.10],                 "break":true  },
+      "10":{ "base":0.10,    "bless":[0.10],                 "break":true  },
+      "11":{ "base":0.05,    "bless":[0.05],                 "break":true  }
+    }
+  }
+  // ... 나머지 유형도 동일한 방식으로 작성 ...
+};

--- a/enhancement.html
+++ b/enhancement.html
@@ -79,6 +79,7 @@
     <button onclick="enhanceAllSteps()">다중강화</button>
   </div>
 
+  <script src="enhance_rates.js"></script>
   <script>
     // 1) entries 선언 및 슬롯 초기화
     const entries = [];
@@ -99,7 +100,7 @@
     function updateStepBar() {
       const item = entries[0];
       const safeLevel = item?.safeLevel || 0;
-      const rateTable = item ? enhanceRates[`${item.type}_${item.safeLevel}`] : null;
+      const rateTable = item ? window.enhanceRates[item.type]?.[item.safeLevel] : null;
       document.querySelectorAll('.step').forEach((el, i) => {
         const level = i + 1;
         const breakable = rateTable?.[String(level - 1)]?.break;
@@ -151,41 +152,10 @@
       updateStepBar();
     }
 
-    // 4) 확률표 완전 통합 (문법 오류 수정 완료)
-    const enhanceRates = {
-      "무기_6": {
-        "0": { "base":1,    "bless":[0.34,0.33,0.33], "break":false },
-        "1": { "base":1,    "bless":[0.34,0.33,0.33], "break":false },
-        "2": { "base":1,    "bless":[0.34,0.33,0.33], "break":false },
-        "3": { "base":1,    "bless":[0.50,0.50],      "break":false },
-        "4": { "base":1,    "bless":[0.50,0.50],      "break":false },
-        "5": { "base":1,    "bless":[0.50,0.50],      "break":false },
-        "6": { "base":0.51, "bless":[0.51],           "break":true  },
-        "7": { "base":0.33, "bless":[0.33],           "break":true  },
-        "8": { "base":0.33, "bless":[0.33],           "break":true  },
-        "9": { "base":0.10, "bless":[0.10],           "break":true  },
-        "10":{ "base":0.04, "bless":[0.04],           "break":true  },
-        "11":{ "base":0.01, "bless":[0.01],           "break":true  }
-      },
-      "방어구_1": {
-        "0": { "base":1,      "bless":[0.3334,0.3333,0.3333], "break":false },
-        "1": { "base":0.7501,  "bless":[0.2501,0.25,0.25],     "break":true  },
-        "2": { "base":0.49,    "bless":[0.1634,0.1633,0.1633], "break":true  },
-        "3": { "base":0.33,    "bless":[0.165,0.165],          "break":true  },
-        "4": { "base":0.25,    "bless":[0.125,0.125],          "break":true  },
-        "5": { "base":0.20,    "bless":[0.10,0.10],            "break":true  },
-        "6": { "base":0.20,    "bless":[0.20],                 "break":true  },
-        "7": { "base":0.15,    "bless":[0.15],                 "break":true  },
-        "8": { "base":0.15,    "bless":[0.15],                 "break":true  },
-        "9": { "base":0.10,    "bless":[0.10],                 "break":true  },
-        "10":{ "base":0.10,    "bless":[0.10],                 "break":true  },
-        "11":{ "base":0.05,    "bless":[0.05],                 "break":true  }
-      }
-      // ... 나머지 유형도 동일한 방식으로 작성 ...
-    };
+    // 4) 확률표는 enhance_rates.js에서 로드
 
     function getEnhanceResult(item, bless) {
-      const rates = enhanceRates[`${item.type}_${item.safeLevel}`]?.[String(item.level)];
+      const rates = window.enhanceRates[item.type]?.[item.safeLevel]?.[String(item.level)];
       if (!rates) return { success:false, destroyed:false, increment:0 };
       let success = false, increment = 1;
       if (bless && rates.bless.length > 1) {


### PR DESCRIPTION
## 요약
- 확률 데이터를 `enhance_rates.js`로 분리
- `enhancement.html`에서 확률표 정의 제거 및 외부 스크립트 로드
- 로직이 `window.enhanceRates`를 사용하도록 수정

## 테스트 결과
- `python3 test_pages.py` 실행하여 모든 테스트 통과


------
https://chatgpt.com/codex/tasks/task_e_685ec5c35ff48331af07157c0aff538b