### PR TITLE
강화 단계 계산 로직 개선

### DIFF
--- a/enhancement.html
+++ b/enhancement.html
@@ -211,10 +211,18 @@
     function getEnhanceResult(item, bless) {
       const rates = window.enhanceRates[item.type]?.[item.safeLevel]?.[String(item.level)];
       if (!rates) return { success:false, destroyed:false, increment:0 };
-      const rate = bless
-        ? rates.bless.reduce((a, b) => a + b, 0)
-        : rates.base;
-      const success = Math.random() < rate;
+      if (bless) {
+        const r = Math.random();
+        let sum = 0;
+        for (let i = 0; i < rates.bless.length; i++) {
+          sum += rates.bless[i];
+          if (r < sum) {
+            return { success:true, destroyed:false, increment:i + 1 };
+          }
+        }
+        return { success:false, destroyed:rates.break, increment:0 };
+      }
+      const success = Math.random() < rates.base;
       return success
         ? { success:true, destroyed:false, increment:1 }
         : { success:false, destroyed:rates.break, increment:0 };


### PR DESCRIPTION
## 변경 사항
- `getEnhanceResult`에서 축복 강화 확률을 배열 순회 방식으로 수정했습니다.
- 다크 모드 및 기존 스타일을 유지하며 로직만 변경했습니다.
- 모든 HTML 페이지의 구조가 유지되는지 테스트(`test_pages.py`)를 통과했습니다.


------
https://chatgpt.com/codex/tasks/task_e_685ed95933d0833199142a434732ecd2