### PR TITLE
강화 시뮬 업데이트

### DIFF
--- a/enhance_rates.js
+++ b/enhance_rates.js
@@ -176,5 +176,45 @@ window.enhanceRates = {
       "10": { "base":0.1, "bless":[0.1], "break":true },
       "11": { "base":0.05, "bless":[0.05], "break":true }
     }
+  },
+  "유물": {
+    "0": {
+      "0": { "base":1.0, "bless":[1.0], "break":false },
+      "1": { "base":0.75, "bless":[0.75], "break":true },
+      "2": { "base":0.6, "bless":[0.6], "break":true },
+      "3": { "base":0.5, "bless":[0.5], "break":true },
+      "4": { "base":0.5, "bless":[0.5], "break":true },
+      "5": { "base":0.25, "bless":[0.25], "break":true },
+      "6": { "base":0.25, "bless":[0.25], "break":true },
+      "7": { "base":0.25, "bless":[0.25], "break":true },
+      "8": { "base":0.25, "bless":[0.25], "break":true },
+      "9": { "base":0.25, "bless":[0.25], "break":true },
+      "10": { "base":0.3333, "bless":[0.3333], "break":true },
+      "11": { "base":0.5, "bless":[0.5], "break":true }
+    }
+  },
+  "페르디타": {
+    "0": {
+      "0": { "base":1.0, "bless":[1.0], "break":false },
+      "1": { "base":0.75, "bless":[0.75], "break":true },
+      "2": { "base":0.6, "bless":[0.6], "break":true },
+      "3": { "base":0.5, "bless":[0.5], "break":true },
+      "4": { "base":0.5, "bless":[0.5], "break":true },
+      "5": { "base":0.25, "bless":[0.25], "break":true },
+      "6": { "base":0.25, "bless":[0.25], "break":true },
+      "7": { "base":0.25, "bless":[0.25], "break":true },
+      "8": { "base":0.25, "bless":[0.25], "break":true },
+      "9": { "base":0.25, "bless":[0.25], "break":true },
+      "10": { "base":0.3333, "bless":[0.3333], "break":true },
+      "11": { "base":0.5, "bless":[0.5], "break":true },
+      "12": { "base":0.5, "bless":[0.5], "break":true },
+      "13": { "base":0.5, "bless":[0.5], "break":true },
+      "14": { "base":0.5, "bless":[0.5], "break":true },
+      "15": { "base":0.5, "bless":[0.5], "break":true },
+      "16": { "base":0.5, "bless":[0.5], "break":true },
+      "17": { "base":0.5, "bless":[0.5], "break":true },
+      "18": { "base":0.5, "bless":[0.5], "break":true },
+      "19": { "base":0.5, "bless":[0.5], "break":true }
+    }
   }
 };

--- a/enhancement.html
+++ b/enhancement.html
@@ -64,6 +64,12 @@
       font-weight: bold;
       font-size: 0.7rem;
       text-align: center;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
     }
     .card .img {
       width: 32px;
@@ -130,7 +136,7 @@
 
     document.addEventListener('DOMContentLoaded', () => {
       entryGrid = document.getElementById('entry-grid');
-      for (let i = 0; i < 20; i++) {
+      for (let i = 0; i < 40; i++) {
         const slot = document.createElement('div');
         slot.className = 'slot';
         entryGrid.appendChild(slot);
@@ -138,7 +144,7 @@
       populateControls();
       document.getElementById('resetBtn').onclick = resetAll;
       document.getElementById("enhance-bar").innerHTML =
-        Array.from({ length: 12 }, (_, i) =>
+        Array.from({ length: 20 }, (_, i) =>
           `<div class="step" onclick="setTargetLevel(${i + 1})">+${i + 1}</div>`
         ).join('');
       updateStepBar();
@@ -172,7 +178,7 @@
         alert('동일한 유형만 등록 가능합니다.');
         return;
       }
-      if (entries.length >= 20) return;
+      if (entries.length >= 40) return;
       entries.push({
         id: Date.now() + Math.random(),
         type,


### PR DESCRIPTION
## 변경 사항
- 강화 시뮬 등록 슬롯을 40개까지 확장
- 단계 선택 바를 +20까지 표시하도록 수정
- 등록 아이템 카드가 정사각형 영역을 가득 채우도록 CSS 개선
- 유물 및 페르디타 확률표 추가

## 테스트
- `python3 test_pages.py` 실행으로 다크 모드 테스트 통과

------
https://chatgpt.com/codex/tasks/task_e_685f015f09488331aa164fb81db8c54b