### PR TITLE
카드 선택 기능 개선

### DIFF
--- a/enhancement.html
+++ b/enhancement.html
@@ -72,6 +72,20 @@
       align-items: center;
       justify-content: center;
     }
+    .card.selected::after {
+      content: '';
+      position: absolute;
+      inset: -2px;
+      border-radius: 6px;
+      border: 2px solid var(--target-color);
+      box-shadow: 0 0 6px var(--target-color);
+      animation: rotateBorder 8s linear infinite;
+      pointer-events: none;
+    }
+    @keyframes rotateBorder {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
     .card .img {
       width: 32px;
       height: 32px;
@@ -190,7 +204,8 @@
         type,
         level: 0,
         safeLevel,
-        destroyed: false
+        destroyed: false,
+        selected: false
       });
       renderEntries();
       updateStepBar();
@@ -199,14 +214,32 @@
       return 'type-' + type.replace(/\s+/g, '-');
     }
 
+    function levelColor(lv) {
+      const hue = 120 - Math.min(lv, 20) * 6;
+      return `hsl(${hue}, 80%, 60%)`;
+    }
+
+    function toggleSelect(id) {
+      const item = entries.find(it => it.id === id);
+      if (item) item.selected = !item.selected;
+      renderEntries();
+      updateStepBar();
+    }
+
+    function selectedEntries() {
+      const sel = entries.filter(it => it.selected);
+      return sel.length ? sel : entries;
+    }
+
     function renderEntries() {
       entryGrid.querySelectorAll('.slot').forEach((slot, i) => {
         slot.innerHTML = '';
         const item = entries[i];
         if (item && !item.destroyed) {
           const card = document.createElement('div');
-          card.className = 'card ' + typeClass(item.type);
+          card.className = 'card ' + typeClass(item.type) + (item.selected ? ' selected' : '');
           card.dataset.id = item.id;
+          card.onclick = () => toggleSelect(item.id);
 
           const img = document.createElement('div');
           img.className = 'img';
@@ -220,6 +253,7 @@
           const level = document.createElement('div');
           level.className = 'level';
           level.textContent = `+${item.level}`;
+          level.style.color = levelColor(item.level);
           card.appendChild(level);
 
           slot.appendChild(card);
@@ -242,7 +276,8 @@
           type,
           level: 0,
           safeLevel,
-          destroyed: false
+          destroyed: false,
+          selected: false
         });
       }
       renderEntries();
@@ -250,7 +285,7 @@
     }
 
     function decreaseAll() {
-      entries.forEach(it => {
+      selectedEntries().forEach(it => {
         if (it.level > 0) it.level--;
       });
       renderEntries();
@@ -290,8 +325,9 @@
     }
 
     async function enhanceOnce(bless = false, useTarget = false) {
+        const targets = selectedEntries();
         if (useTarget) {
-          entries.forEach(it => {
+          targets.forEach(it => {
             if (it.level < it.safeLevel && selectedTarget >= it.safeLevel) {
               it.level = it.safeLevel;
             }
@@ -299,7 +335,7 @@
         }
         renderEntries();
 
-      const promises = entries.map(item => {
+      const promises = targets.map(item => {
         if (item.destroyed) return Promise.resolve();
         if (useTarget) {
           if (item.level >= selectedTarget) return Promise.resolve();
@@ -330,7 +366,7 @@
     }
 
     async function enhanceAllSteps() {
-      while (entries.some(it => !it.destroyed && it.level < selectedTarget)) {
+      while (selectedEntries().some(it => !it.destroyed && it.level < selectedTarget)) {
         await enhanceOnce(false, true);
         await new Promise(r => requestAnimationFrame(r));
       }


### PR DESCRIPTION
## 변경 사항
- 카드 선택 토글 기능을 추가하여 선택된 카드에만 강화 동작 적용
- 선택된 카드에 회전 및 글로우 효과 부여
- 강화 단계에 따라 텍스트 색상 표시

## 테스트 결과
- `python3 test_pages.py` 실행하여 모든 테스트 통과

------
https://chatgpt.com/codex/tasks/task_e_685f163b282483318aabbb2371cb50ac