### PR TITLE
강화 시뮬 테두리 회전 효과 개선

### DIFF
--- a/enhancement.html
+++ b/enhancement.html
@@ -79,12 +79,15 @@
       border-radius: 6px;
       border: 2px solid var(--target-color);
       box-shadow: 0 0 6px var(--target-color);
-      animation: rotateBorder 8s linear infinite;
+      background: conic-gradient(#fff, var(--target-color) 30deg, var(--target-color) 60deg, #fff 100deg);
+      -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+      -webkit-mask-composite: xor;
+              mask-composite: exclude;
+      animation: rotateHighlight 8s linear infinite;
       pointer-events: none;
     }
-    @keyframes rotateBorder {
-      from { transform: rotate(0deg); }
-      to { transform: rotate(360deg); }
+    @keyframes rotateHighlight {
+      to { transform: rotate(1turn); }
     }
     .card .img {
       width: 32px;


### PR DESCRIPTION
## 변경 내용
- 선택된 카드 테두리 애니메이션을 회전 변형 대신 그라데이션이 회전하는 방식으로 수정
- 기존 `rotateBorder` 키프레임을 `rotateHighlight`로 교체

## 테스트 결과
- `pytest` 실행 결과 전체 테스트 통과


------
https://chatgpt.com/codex/tasks/task_e_685f1cf6bd5c8331969669c229a3fab4